### PR TITLE
Add basic og:image support for our blogposts

### DIFF
--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -5,13 +5,14 @@ type: post
 date: {{ .Date }}
 url: /{{ .Name | urlize }}/
 language: de
-# featured_image:
 # categories:
 #   - Workshops
 # tags:
 #   - LoRaWAN
 #   - Open Data Day
 #   - TTN
+# images:
+#   - /wp-content/uploads/..../../titleimage.jpg
 draft: true
 ---
 

--- a/content/groups/ttn.de.md
+++ b/content/groups/ttn.de.md
@@ -21,7 +21,7 @@ Alle zwei Wochen am Mittwochabend, ab 18:30 Uhr.
 
 Dabei gibt's im vierwöchentlichen Wechsel einmal einen “Offenen Abend” und einmal den “Bastelabend”. komm' rein und einfach durchgehen, bis zum Lötlabor. Wenn du dich nicht zurecht findest, trau' dich gerne jede:n anzusprechen. Manchmal ist in den vorderen Räumen wenig Licht an, lass' dich davon nicht aufhalten und komm nach hinten.
 
-Den nächsten Termin findest du im [Kalender]({{< relref "/termine-und-oeffnungszeiten.md" >}}).
+Den nächsten Termin findest du im [Kalender](/termine-und-oeffnungszeiten/).
 
 **Kontakt**
 

--- a/content/posts/2024-01-15-silvesterglueck-monatsbericht-dezember-2023.de.md
+++ b/content/posts/2024-01-15-silvesterglueck-monatsbericht-dezember-2023.de.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/01/monatsbericht_titel.jpg
+images: 
+  - /wp-content/uploads/2024/01/monatsbericht_titel.jpg
 ---
 
 Das erste Silvester im neuen Haus ist gefeiert, der Dezember und das damit verbundene Jahresendfieber sind abgeschlossen. Zeit für einen Rückblick!

--- a/content/posts/2024-01-15-silvesterglueck-monatsbericht-dezember-2023.en.md
+++ b/content/posts/2024-01-15-silvesterglueck-monatsbericht-dezember-2023.en.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/01/monatsbericht_titel.jpg
+images: 
+  - /wp-content/uploads/2024/01/monatsbericht_titel.jpg
 ---
 
 We just celebreated our first new year's eve in the new space, December and the year-end sprint that came with it are over. Time for a look back!

--- a/content/posts/2024-01-28-ordnung-trotz-chaos-neue-regale-und-lagerkisten.de.md
+++ b/content/posts/2024-01-28-ordnung-trotz-chaos-neue-regale-und-lagerkisten.de.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/01/dsee_regal.jpg
+images: 
+  - /wp-content/uploads/2024/01/dsee_regal.jpg
 ---
 
 _Dieser Artikel ist Teil einer Serie, in der wir einige unserer neuen, wertvollen Anschaffungen vorstellen möchten, die wir dank einer Förderung durch die [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/) umsetzen konnten._

--- a/content/posts/2024-01-28-ordnung-trotz-chaos-neue-regale-und-lagerkisten.en.md
+++ b/content/posts/2024-01-28-ordnung-trotz-chaos-neue-regale-und-lagerkisten.en.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/01/dsee_regal.jpg
+images: 
+  - /wp-content/uploads/2024/01/dsee_regal.jpg
 ---
 
 _This post is part of a series in which we want to present some of our new and valuable material that we were able to procure due to a grant by [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/)._

--- a/content/posts/2024-02-06-der-sprudelfaktor-monatsbericht-januar-2024.de.md
+++ b/content/posts/2024-02-06-der-sprudelfaktor-monatsbericht-januar-2024.de.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/02/monatsbericht_naehcafe.jpg
+images: 
+  - /wp-content/uploads/2024/02/monatsbericht_naehcafe.jpg
 ---
 
 Schon wieder ist ein Monat vorbei, Zeit für den Rückblick auf den Januar! Mit **18 öffentlichen Veranstaltungen**, einem offiziellen Besuch bei uns und mindestens einem Auswärtstermin haben wir zum Jahresauftakt gleich einen neuen Rekord geschafft.

--- a/content/posts/2024-02-06-der-sprudelfaktor-monatsbericht-januar-2024.en.md
+++ b/content/posts/2024-02-06-der-sprudelfaktor-monatsbericht-januar-2024.en.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/02/monatsbericht_naehcafe.jpg
+images: 
+  - /wp-content/uploads/2024/02/monatsbericht_naehcafe.jpg
 ---
 
 Another month has passed, time to look back on January! With **18 public events**, one official visit to us and at least one away mission, we set a new record at the start of the year.

--- a/content/posts/2024-02-12-mehr-druck-der-bambu-3d-drucker.de.md
+++ b/content/posts/2024-02-12-mehr-druck-der-bambu-3d-drucker.de.md
@@ -10,7 +10,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/02/dsee_bambu1.jpg
+images:
+  - /wp-content/uploads/2024/02/dsee_bambu1.jpg
 ---
 
 _Dieser Artikel ist Teil einer Serie, in der wir einige unserer neuen, wertvollen Anschaffungen vorstellen möchten, die wir dank einer Förderung durch die [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/) umsetzen konnten._

--- a/content/posts/2024-02-12-mehr-druck-der-bambu-3d-drucker.en.md
+++ b/content/posts/2024-02-12-mehr-druck-der-bambu-3d-drucker.en.md
@@ -10,7 +10,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/02/dsee_bambu1.jpg
+images: 
+  - /wp-content/uploads/2024/02/dsee_bambu1.jpg
 ---
 
 _This post is part of a series in which we want to present some of our new and valuable material that we were able to procure due to a grant by [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/)._

--- a/content/posts/2024-02-29-besser-sticken-mit-pr1x.de.md
+++ b/content/posts/2024-02-29-besser-sticken-mit-pr1x.de.md
@@ -10,7 +10,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/02/dsee_stickmaschine.jpg
+images: 
+  - /wp-content/uploads/2024/02/dsee_stickmaschine.jpg
 ---
 
 _Dieser Artikel ist Teil einer Serie, in der wir einige unserer neuen, wertvollen Anschaffungen vorstellen möchten, die wir dank einer Förderung durch die [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/) umsetzen konnten._

--- a/content/posts/2024-02-29-besser-sticken-mit-pr1x.en.md
+++ b/content/posts/2024-02-29-besser-sticken-mit-pr1x.en.md
@@ -10,7 +10,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/02/dsee_stickmaschine.jpg
+images: 
+  - /wp-content/uploads/2024/02/dsee_stickmaschine.jpg
 ---
 
 _This post is part of a series in which we want to present some of our new and valuable material that we were able to procure due to a grant by [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/)._

--- a/content/posts/2024-03-16-winterendspurt-monatsbericht-februar-2024.de.md
+++ b/content/posts/2024-03-16-winterendspurt-monatsbericht-februar-2024.de.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/03/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/03/monatsbericht-titel.jpg
 ---
 
 Der Februar ist zwar der kürzeste Monat im Jahr, in den 29 Tagen haben wir es aber dennoch geschafft, **16 eigene öffentliche Termine** unterzubringen – und zusätzlich einen Auswärtsbesuch in Backnang, einen F.U.C.K.-Vernetzungsworkshop bei uns im Haus und natürlich wieder viele interne Arbeitseinsätze.

--- a/content/posts/2024-03-16-winterendspurt-monatsbericht-februar-2024.en.md
+++ b/content/posts/2024-03-16-winterendspurt-monatsbericht-februar-2024.en.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/03/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/03/monatsbericht-titel.jpg
 ---
 
 Although February is the shortest month of the year, we still managed to fit in **16 of our own public appointments** in the 29 days – plus an external visit to Backnang, an F.U.C.K. networking workshop in our premises and, of course, lots of internal work assignments.

--- a/content/posts/2024-03-23-lokalicon-treffen-der-lokalen-community-raeume.de.md
+++ b/content/posts/2024-03-23-lokalicon-treffen-der-lokalen-community-raeume.de.md
@@ -10,7 +10,8 @@ tags:
   - WMDE
   - Wikimedia
   - Wikipedia
-featured_image: /wp-content/uploads/2024/03/lokalicon-titel.jpg
+images: 
+  - /wp-content/uploads/2024/03/lokalicon-titel.jpg
 ---
 
 Vom 22. bis zum 24. März treffen sich gerade über 20 ehrenamtliche Wikipedia-Aktive aus Berlin, Fürth, Hannover, München und Neu-Ulm für ein Vernetzungstreffen im temporärhaus. Sie alle sind in den über Deutschland verteilten [Lokalen Community-Räumen](https://de.wikipedia.org/wiki/Wikipedia:F%C3%B6rderung/Lokale_Community-R%C3%A4ume) aktiv, also Anlaufpunkten in Ladenlokalen, in denen sie gemeinsam mit der jeweiligen Stadtgesellschaft an Freiem Wissen in der Wikipedia und ihren Schwesterprojekten arbeiten können.

--- a/content/posts/2024-03-23-lokalicon-treffen-der-lokalen-community-raeume.en.md
+++ b/content/posts/2024-03-23-lokalicon-treffen-der-lokalen-community-raeume.en.md
@@ -10,7 +10,8 @@ tags:
   - WMDE
   - Wikimedia
   - Wikipedia
-featured_image: /wp-content/uploads/2024/03/lokalicon-titel.jpg
+images: 
+  - /wp-content/uploads/2024/03/lokalicon-titel.jpg
 ---
 
 From March 22 to 24, more than 20 Wikipedia volunteers from Berlin, Fürth, Hanover, Munich and Neu-Ulm are meeting for a networking event at temporärhaus. They are all active in the [Local Community Spaces](https://de.wikipedia.org/wiki/Wikipedia:F%C3%B6rderung/Lokale_Community-R%C3%A4ume) spread across Germany, i.e. contact points in former stores within the city where they can work together with the respective urban community on Free Knowledge in Wikipedia and its sister projects.

--- a/content/posts/2024-03-28-unsere-fotodrohne.de.md
+++ b/content/posts/2024-03-28-unsere-fotodrohne.de.md
@@ -10,7 +10,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/03/dsee-titel.jpg
+images: 
+  - /wp-content/uploads/2024/03/dsee-titel.jpg
 ---
 
 _Dieser Artikel ist Teil einer Serie, in der wir einige unserer neuen, wertvollen Anschaffungen vorstellen möchten, die wir dank einer Förderung durch die [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/) umsetzen konnten._

--- a/content/posts/2024-03-28-unsere-fotodrohne.en.md
+++ b/content/posts/2024-03-28-unsere-fotodrohne.en.md
@@ -10,7 +10,8 @@ categories:
 tags:
   - finanzierung
   - meta
-featured_image: /wp-content/uploads/2024/03/dsee-titel.jpg
+images: 
+  - /wp-content/uploads/2024/03/dsee-titel.jpg
 ---
 
 _This post is part of a series in which we want to present some of our new and valuable material that we were able to procure due to a grant by [Deutsche Stiftung für Engagement und Ehrenamt](https://www.deutsche-stiftung-engagement-und-ehrenamt.de/)._

--- a/content/posts/2024-04-03-auf-zur-sommerzeit-monatsbericht-maerz-2024.de.md
+++ b/content/posts/2024-04-03-auf-zur-sommerzeit-monatsbericht-maerz-2024.de.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/04/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/04/monatsbericht-titel.jpg
 ---
 
 Sonne! 

--- a/content/posts/2024-04-03-auf-zur-sommerzeit-monatsbericht-maerz-2024.en.md
+++ b/content/posts/2024-04-03-auf-zur-sommerzeit-monatsbericht-maerz-2024.en.md
@@ -11,7 +11,8 @@ categories:
 tags:
   - umbau
   - transparenz
-featured_image: /wp-content/uploads/2024/04/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/04/monatsbericht-titel.jpg
 ---
 
 Sun! 

--- a/content/posts/2024-04-24-das-jugend-hackt-lab-startet-wieder-nun-in-neu-ulm.de.md
+++ b/content/posts/2024-04-24-das-jugend-hackt-lab-startet-wieder-nun-in-neu-ulm.de.md
@@ -11,7 +11,8 @@ tags:
   - JugendhacktLab
   - Workshop
   - Löten
-featured_image: /wp-content/uploads/2024/04/jhacktlab-titel.jpg
+images: 
+  - /wp-content/uploads/2024/04/jhacktlab-titel.jpg
 ---
 
 Ab Samstag, dem 27. April um 14 Uhr gibt es wieder ein Jugend hackt Lab in der Doppelstadt – nun auf der anderen Seite der Donau. Beim ersten Workshop geht es ums Löten lernen, denn das ist die Grundlage für viele Hardwareprojekte. Und ganz nebenbei hat man am Ende etwas schönes gebaut!

--- a/content/posts/2024-04-24-das-jugend-hackt-lab-startet-wieder-nun-in-neu-ulm.en.md
+++ b/content/posts/2024-04-24-das-jugend-hackt-lab-startet-wieder-nun-in-neu-ulm.en.md
@@ -11,7 +11,8 @@ tags:
   - JugendhacktLab
   - Workshop
   - Löten
-featured_image: /wp-content/uploads/2024/04/jhacktlab-titel.jpg
+images: 
+  - /wp-content/uploads/2024/04/jhacktlab-titel.jpg
 ---
 
 From Saturday, April 27 at 2 p.m., there will be another Jugend hackt Lab in the twin city—now on the other side of the Danube. The first workshop is all about learning to solder, as this is the basis for many hardware projects. And by the way, you'll have built something nice in the end!

--- a/content/posts/2024-05-24-kein-aprilscherz-monatsbericht-april-2024.de.md
+++ b/content/posts/2024-05-24-kein-aprilscherz-monatsbericht-april-2024.de.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/05/monatsbericht-hej.jpg
+images: 
+  - /wp-content/uploads/2024/05/monatsbericht-hej.jpg
 ---
 
 Der April ist nun schon ein paar Wochen vorbei – eventuell berichten wir erst jetzt davon, weil wir erst einmal einen im März erreichten Meilenstein nachholend feiern mussten ;)  

--- a/content/posts/2024-05-24-kein-aprilscherz-monatsbericht-april-2024.en.md
+++ b/content/posts/2024-05-24-kein-aprilscherz-monatsbericht-april-2024.en.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/05/monatsbericht-hej.jpg
+images: 
+  - /wp-content/uploads/2024/05/monatsbericht-hej.jpg
 ---
 
 April has been over for a few weeks now—we may only be reporting on it now because we first had to catch up and celebrate a milestone we reached in March ;)

--- a/content/posts/2024-06-01-kleine-datenanlyse-zur-ulmer-gemeinderatswahl-am-9-6-2024.de.md
+++ b/content/posts/2024-06-01-kleine-datenanlyse-zur-ulmer-gemeinderatswahl-am-9-6-2024.de.md
@@ -5,7 +5,8 @@ title: Wie alt sind unsere Kandidat:innen? Kleine Daten-Analyse zur
   Gemeinderatswahl in Ulm am 9.6.2024
 author: Simon Lüke, Jakob Pietron
 date: 2024-06-01T13:27:38.763Z
-featured_image: /wp-content/uploads/2024/06/datenalanyse-wahl2024-gemeinderat-bevoelkerung-listen_einzeln.png
+images: 
+  - /wp-content/uploads/2024/06/datenalanyse-wahl2024-gemeinderat-bevoelkerung-listen_einzeln.png
 categories:
   - news
 tags:

--- a/content/posts/2024-06-13-wasserstand-mail-2024.de.md
+++ b/content/posts/2024-06-13-wasserstand-mail-2024.de.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/06/monatsbericht-schild.jpg
+images: 
+  - /wp-content/uploads/2024/06/monatsbericht-schild.jpg
 ---
 
 Der Mai ist vorbei – und bis zur Hochwasserlage am Monatsende war es beinahe Business as Usual. Beinahe, denn in Süddeutschland war das wieder so ein Monat, in dem praktisch in jeder Woche ein Feiertag lag, weswegen (und wegen einer Erkrankung) ein paar der Termine ausfielen. 

--- a/content/posts/2024-06-13-wasserstand-mail-2024.en.md
+++ b/content/posts/2024-06-13-wasserstand-mail-2024.en.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/06/monatsbericht-schild.jpg
+images: 
+  - /wp-content/uploads/2024/06/monatsbericht-schild.jpg
 ---
 
 May is over—and until the floods at the end of the month, it was almost business as usual. 

--- a/content/posts/2024-07-14-katastrophenalarm-und-hausmeisterei-monatsbericht-juni-2024.de.md
+++ b/content/posts/2024-07-14-katastrophenalarm-und-hausmeisterei-monatsbericht-juni-2024.de.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/07/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/07/monatsbericht-titel.jpg
 ---
 
 Der Juni begann mit sich stapelnden Warnungen des Deutschen Wetterdienstes und des Hochwassernachrichtendienst Bayern: 

--- a/content/posts/2024-07-14-katastrophenalarm-und-hausmeisterei-monatsbericht-juni-2024.en.md
+++ b/content/posts/2024-07-14-katastrophenalarm-und-hausmeisterei-monatsbericht-juni-2024.en.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/07/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/07/monatsbericht-titel.jpg
 ---
 
 June began with a heap of warnings from the German Weather Service and the Bavarian Flood Information Service:

--- a/content/posts/2024-07-24-freie-bilder-vom-schwoermontag.de.md
+++ b/content/posts/2024-07-24-freie-bilder-vom-schwoermontag.de.md
@@ -9,7 +9,8 @@ categories:
 tags:
   - Freies Wissen
   - Wikipedia
-featured_image: /wp-content/uploads/2024/07/schwoemo-titel.jpg
+images: 
+  - /wp-content/uploads/2024/07/schwoemo-titel.jpg
 ---
 
 Exakt zwei Stunden. 

--- a/content/posts/2024-07-24-freie-bilder-vom-schwoermontag.en.md
+++ b/content/posts/2024-07-24-freie-bilder-vom-schwoermontag.en.md
@@ -9,7 +9,8 @@ categories:
 tags:
   - Freies Wissen
   - Wikipedia
-featured_image: /wp-content/uploads/2024/07/schwoemo-titel.jpg
+images: 
+  - /wp-content/uploads/2024/07/schwoemo-titel.jpg
 ---
 
 Exactly two hours. 

--- a/content/posts/2024-08-08-lokalfeiertag-monatsbericht-juli-2024.de.md
+++ b/content/posts/2024-08-08-lokalfeiertag-monatsbericht-juli-2024.de.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/08/monatsbericht-brennofen.jpg
+images: 
+  - /wp-content/uploads/2024/08/monatsbericht-brennofen.jpg
 ---
 
 Es ist Sommer in der Stadt und das merkt man auch: Menschen tummelten sich im Juli an und auf der Donau und sonstigen Badegewässern und spätestens mit Beginn der Ferien leerten sich die Straßen. 

--- a/content/posts/2024-08-08-lokalfeiertag-monatsbericht-juli-2024.en.md
+++ b/content/posts/2024-08-08-lokalfeiertag-monatsbericht-juli-2024.en.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/08/monatsbericht-brennofen.jpg
+images: 
+  - /wp-content/uploads/2024/08/monatsbericht-brennofen.jpg
 ---
 
 You can tell it's summer in the city: people frolicked on the Danube and other bodies of water in July and the streets emptied out as soon as the vacations began.

--- a/content/posts/2024-08-18-baytex-am-07-09-2024.de.md
+++ b/content/posts/2024-08-18-baytex-am-07-09-2024.de.md
@@ -8,7 +8,8 @@ categories:
   - news
 tags:
   - LaTeX
-featured_image: /wp-content/uploads/2024/08/latex_logo.png
+images: 
+  - /wp-content/uploads/2024/08/latex_logo.png
 ---
 
 [LaTeX](https://de.wikipedia.org/wiki/LaTeX) ist ein enorm mächtiges Softwarepaket für digitalen Textsatz, das vor allem – aber nicht nur – in der Wissenschaft für typographisch schön gesetzte Texte verwendet wird.

--- a/content/posts/2024-08-18-baytex-am-07-09-2024.en.md
+++ b/content/posts/2024-08-18-baytex-am-07-09-2024.en.md
@@ -8,7 +8,8 @@ categories:
   - news
 tags:
   - LaTeX
-featured_image: /wp-content/uploads/2024/08/latex_logo.png
+images: 
+  - /wp-content/uploads/2024/08/latex_logo.png
 ---
 
 [LaTeX](https://de.wikipedia.org/wiki/LaTeX) is an enormously powerful software package for digital text typesetting, which is mainly—but not only–used in academia for typographically beautifully set texts.

--- a/content/posts/2024-08-24-wiki-loves-monuments-2024-fotowettbewerb.de.md
+++ b/content/posts/2024-08-24-wiki-loves-monuments-2024-fotowettbewerb.de.md
@@ -3,7 +3,8 @@ title: "Wiki loves Monuments 2024, der Fotowettbewerb rund um Kulturdenkmäler s
 author: Stefan Kaufmann
 date: 2024-08-24T15:23:49.793Z
 draft: false
-featured_image: /wp-content/uploads/2024/08/wlm_muenster.jpg
+images: 
+  - /wp-content/uploads/2024/08/wlm_muenster.jpg
 categories:
   - news
 tags:

--- a/content/posts/2024-09-19-spaetsommer-ueber-der-stadt-monatsbericht-august-2024.de.md
+++ b/content/posts/2024-09-19-spaetsommer-ueber-der-stadt-monatsbericht-august-2024.de.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/09/monatsbericht-titel.jpg
+images: 
+  - /wp-content/uploads/2024/09/monatsbericht-titel.jpg
 ---
 
 August: Lange Sommerabende, die Menschen kehren in die Stadt zurück und verbringen die langen Abende am Ufer der Donau, das dieses Jahr wegen der angeschwemmten Kiesbänke und des abgesenkten Flusspegels _ganz_ anders aussieht und zum Verweilen auf Strandstühlen einlädt.

--- a/content/posts/2024-09-21-kulturnacht-2024.de.md
+++ b/content/posts/2024-09-21-kulturnacht-2024.de.md
@@ -8,7 +8,8 @@ language: de
 draft: false
 categories:
   - news
-featured_image: /wp-content/uploads/2024/09/kulturnacht2024-regal.jpg
+images: 
+  - /wp-content/uploads/2024/09/kulturnacht2024-regal.jpg
 
 ---
 Auch dieses Jahr ist das temporärhaus Teil der [Kulturnacht Ulm 2024][1]. Zusammen mit dem [Haus der Nachhaltigkeit][2] öffnen wir von 15:00-01:30 Uhr unsere Türen.

--- a/content/posts/2024-10-10-ein-jahr-am-neuen-ort.de.md
+++ b/content/posts/2024-10-10-ein-jahr-am-neuen-ort.de.md
@@ -9,7 +9,8 @@ categories:
   - monatsbericht
 tags:
   - transparenz
-featured_image: /wp-content/uploads/2024/10/monatsbericht-titel.jpg
+images:
+  - /wp-content/uploads/2024/10/monatsbericht-titel.jpg
 ---
 
 Das Ende des September heißt auch: Wir haben das erste Jahr seit der offiziellen Wiedereröffnung am neuen Standort in Neu-Ulm gemeinsam mit dem [Haus der Nachhaltigkeit](https://www.h-d-n.org/) vollendet. 

--- a/layouts/partials/index-fullwidth.html
+++ b/layouts/partials/index-fullwidth.html
@@ -2,7 +2,7 @@
   <section class="fullwidth">
     <div class="fullwidth-bg">
       {{- $featured_image := .Params.featured_image }}
-      {{- if not $featured_image }}
+      {{- if and (not $featured_image) .Params.images }}
         {{- range first 1 .Params.images }}
           {{- $featured_image = . }}
         {{- end }}

--- a/layouts/partials/index-fullwidth.html
+++ b/layouts/partials/index-fullwidth.html
@@ -1,7 +1,13 @@
 {{ range first 1 (where .Site.Pages ".Params.sticky" true) }}
   <section class="fullwidth">
     <div class="fullwidth-bg">
-      <img src="{{ .Params.featured_image }}" />
+      {{- $featured_image := .Params.featured_image }}
+      {{- if not $featured_image }}
+        {{- range first 1 .Params.images }}
+          {{- $featured_image = . }}
+        {{- end }}
+      {{- end }}
+      <img src="{{ $featured_image }}" />
     </div>
     <div class="fullwidth-content">
       <div class="floating-teaser">

--- a/themes/twentysixteen/layouts/_default/single.html
+++ b/themes/twentysixteen/layouts/_default/single.html
@@ -8,7 +8,7 @@
     </header><!-- .entry-header -->
 
     {{- $featured_image := .Params.featured_image }}
-    {{- if not $featured_image }}
+    {{- if and (not $featured_image) .Params.images }}
       {{- range first 1 .Params.images }}
         {{- $featured_image = . }}
       {{- end }}

--- a/themes/twentysixteen/layouts/_default/single.html
+++ b/themes/twentysixteen/layouts/_default/single.html
@@ -7,9 +7,16 @@
         </h1>
     </header><!-- .entry-header -->
 
-    {{ if .Params.featured_image }}
+    {{- $featured_image := .Params.featured_image }}
+    {{- if not $featured_image }}
+      {{- range first 1 .Params.images }}
+        {{- $featured_image = . }}
+      {{- end }}
+    {{- end }}
+
+    {{ if $featured_image }}
     <div class="post-thumbnail">
-        <img src="{{ .Params.featured_image }}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="{{ .Title }}" />
+        <img src="{{ $featured_image }}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="{{ .Title }}" />
     </div>
     {{ end }}
 

--- a/themes/twentysixteen/layouts/partials/article-full.html
+++ b/themes/twentysixteen/layouts/partials/article-full.html
@@ -7,9 +7,16 @@
     </header>
     <!-- .entry-header -->
 
-    {{ if .Params.featured_image }}
+    {{- $featured_image := .Params.featured_image }}
+    {{- if not $featured_image }}
+      {{- range first 1 .Params.images }}
+        {{- $featured_image = . }}
+      {{- end }}
+    {{- end }}
+
+    {{ if $featured_image }}
     <a class="post-thumbnail" href="{{ .Permalink }}" aria-hidden="true">
-        <img src="{{ .Params.featured_image }}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="{{ .Title }}" />
+        <img src="{{ $featured_image }}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="{{ .Title }}" />
     </a>
     {{ end }}
 

--- a/themes/twentysixteen/layouts/partials/article-full.html
+++ b/themes/twentysixteen/layouts/partials/article-full.html
@@ -8,7 +8,7 @@
     <!-- .entry-header -->
 
     {{- $featured_image := .Params.featured_image }}
-    {{- if not $featured_image }}
+    {{- if and (not $featured_image) .Params.images }}
       {{- range first 1 .Params.images }}
         {{- $featured_image = . }}
       {{- end }}

--- a/themes/twentysixteen/layouts/partials/article-summary.html
+++ b/themes/twentysixteen/layouts/partials/article-summary.html
@@ -7,9 +7,16 @@
     </header>
     <!-- .entry-header -->
 
-    {{ if .Params.featured_image }}
+    {{- $featured_image := .Params.featured_image }}
+    {{- if not $featured_image }}
+      {{- range first 1 .Params.images }}
+        {{- $featured_image = . }}
+      {{- end }}
+    {{- end }}
+
+    {{ if $featured_image }}
     <a class="post-thumbnail" href="{{ .Permalink }}" aria-hidden="true">
-        <img src="{{ .Params.featured_image }}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="{{ .Title }}" />
+        <img src="{{ $featured_image }}" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="{{ .Title }}" />
     </a>
     {{ end }}
 

--- a/themes/twentysixteen/layouts/partials/article-summary.html
+++ b/themes/twentysixteen/layouts/partials/article-summary.html
@@ -8,7 +8,7 @@
     <!-- .entry-header -->
 
     {{- $featured_image := .Params.featured_image }}
-    {{- if not $featured_image }}
+    {{- if and (not $featured_image) .Params.images }}
       {{- range first 1 .Params.images }}
         {{- $featured_image = . }}
       {{- end }}


### PR DESCRIPTION
Erm, or, more likely the other way around :D 
By using the hugo standardized `images` array in frontmatter and no longer our self-defined `featured_image` param, we can profit from the usage of the image array in hugos `og:image` search: https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/partials/_funcs/get-page-images.html

I've modified the latest blog post as an example, this is something we should do for every old and all the new blogposts too.